### PR TITLE
docs: 补充 v1.0.1 更新日志

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,4 +4,5 @@
 
 ## 已发布
 
+- [v1.0.1](https://github.com/xweiba/location-spoofer/releases/tag/v1.0.1) — 2026-08-06
 - [v1.0.0](https://github.com/xweiba/location-spoofer/releases/tag/v1.0.0) — 2026-08-05


### PR DESCRIPTION
## 改动内容

- 在更新日志的“已发布”列表中补充 v1.0.1
- 链接到现有的 v1.0.1 GitHub Release，并标注发布日期

## 原因

README 的版本徽章和版本归档已经指向 v1.0.1，但更新日志仍只列出 v1.0.0，信息不一致。

## 影响

用户可以从更新日志直接访问当前版本的发布页面。本次仅修改文档，不影响应用行为。

## 校验

- `git diff --check`
- 确认 `docs/CHANGELOG.md` 为 UTF-8
- 通过 GitHub API 确认 v1.0.1 Release 存在
