### PR TITLE
docs: 完善自签安装步骤

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -65,10 +65,18 @@ Unlike tools that require a computer to stay connected, developer debugging, or 
 
 ### 1. Install the App
 
-- Download a build from [Releases](https://github.com/xweiba/location-spoofer/releases) and self-sign; or
-- Build from source on macOS with Xcode — see the [build guide](docs/BUILD.md).
+Release assets are unsigned IPA files and must be installed with a sideloading tool:
 
-The release asset is an unsigned IPA. Sign it with [Impact](https://github.com/claration/Impactor) before installation. Keep the app Bundle ID `com.paopaolabs.location-spoofer`, the App Group `group.com.paopaolabs.location-spoofer`, and the declared entitlements unchanged. A free Apple ID signature normally expires after seven days and must then be renewed; this is separate from the WLOC CA certificate.
+1. **Enable sideloading support**: On iOS 16 or later, open Settings → Privacy & Security → Developer Mode, enable it, then restart and confirm when prompted. iOS 15 does not have this switch, so skip this step there.
+2. **Download the IPA**: Open this project's [Releases](https://github.com/xweiba/location-spoofer/releases) and download the latest `PaopaoLocationSpoofer-unsigned.ipa`.
+3. **Prepare a sideloading tool**: Download the appropriate Impact build from [Impact Releases](https://github.com/claration/Impactor/releases/latest). Aisi Assistant/i4Tools or another tool that supports signing and installing IPA files may also be used.
+4. **Connect and install**: Connect the iPhone to the computer with a USB cable, tap “Trust This Computer” on the phone, select the downloaded IPA in the sideloading tool, and follow that tool's prompts to sign and install it.
+
+> Impact supports Windows, macOS, and Linux. If Windows cannot detect the device, install iTunes to provide the Apple device drivers. Aisi Assistant/i4Tools is third-party software; download it only from its official source and assess its account, certificate, and privacy risks yourself.
+
+If iOS blocks the installed app, trust its developer app under Settings → General → VPN & Device Management. A free Apple ID signature normally expires after seven days and must then be renewed; this is separate from the WLOC CA certificate. Keep the app Bundle ID `com.paopaolabs.location-spoofer`, the App Group `group.com.paopaolabs.location-spoofer`, and the declared entitlements unchanged.
+
+To build the unsigned IPA yourself on macOS with Xcode, follow the [build guide](docs/BUILD.md), then use the same sideloading steps above to sign and install it.
 
 ### 2. Choose a Runtime Mode
 

--- a/README.md
+++ b/README.md
@@ -84,12 +84,20 @@
 
 ### 1. 安装 App
 
-- 从 [Releases](https://github.com/xweiba/location-spoofer/releases) 获取构建产物并自行签名；或
-- 在 macOS + Xcode 环境按[构建说明](docs/BUILD.md)编译。
-
 #### 自签安装
 
-免费 Apple ID 可用于侧载，无需付费开发者账号。本项目自身不包含 VPN、Network Extension 或 Packet Tunnel Provider，但签名工具仍需保留 App 的标识和声明能力。
+Release 附件是未签名 IPA，需要使用自签工具安装到 iPhone：
+
+1. **开启自签支持**：iOS 16 及以上版本前往“设置 → 隐私与安全性 → 开发者模式”，开启后按系统提示重启并确认；iOS 15 没有此开关，可跳过本步。
+2. **下载 IPA**：前往本项目的 [Releases](https://github.com/xweiba/location-spoofer/releases)，下载最新的 `PaopaoLocationSpoofer-unsigned.ipa`。
+3. **准备自签软件**：前往 [Impact Releases](https://github.com/claration/Impactor/releases/latest) 下载对应系统版本的 Impact；也可以使用爱思助手等支持 IPA 自签安装的软件。
+4. **连接并安装**：使用 USB 数据线连接 iPhone 与电脑，在手机上选择“信任此电脑”，然后在自签软件中选择刚下载的 IPA，根据软件提示完成签名与安装。
+
+> Impact 支持 Windows、macOS 和 Linux；Windows 若无法识别设备，请先安装 iTunes 提供 Apple 设备驱动。爱思助手属于第三方软件，请从其官方渠道获取，并自行评估账号、证书和隐私风险。
+
+安装完成后，若 iOS 阻止打开 App，请前往“设置 → 通用 → VPN 与设备管理”信任对应的开发者 App。免费 Apple ID 自签通常只有 7 天有效期，到期后需要重新签名安装。
+
+本项目自身不包含 VPN、Network Extension 或 Packet Tunnel Provider，但签名工具仍需保留 App 的标识和声明能力。
 
 需要自行构建时执行：
 
@@ -97,7 +105,7 @@
 ./build.sh
 ```
 
-输出文件为 `dist/PaopaoLocationSpoofer-unsigned.ipa`。也可以直接下载 Release 附带的未签名 IPA，然后使用 [Impact](https://github.com/claration/Impactor) 签名并安装到设备。
+输出文件为 `dist/PaopaoLocationSpoofer-unsigned.ipa`，随后按上面的自签步骤安装到设备。完整构建要求见[构建说明](docs/BUILD.md)。
 
 签名时不要修改以下标识，也不要移除 App Group 和 Wi-Fi 信息能力：
 
@@ -105,7 +113,7 @@
 |---|---|
 | 主 App Bundle ID | `com.paopaolabs.location-spoofer` |
 
-免费 Apple ID 签名通常只有 7 天有效期，到期后需要重新签名安装；这是 Apple 的侧载限制，不是 WLOC CA 失效。CA 私钥保存在 iOS 钥匙串中：相同 Bundle ID 和钥匙串访问范围下重装通常可以复用，但卸载、系统清理或签名能力变化后不保证保留。
+签名有效期是 Apple 的侧载限制，不是 WLOC CA 失效。CA 私钥保存在 iOS 钥匙串中：相同 Bundle ID 和钥匙串访问范围下重装通常可以复用，但卸载、系统清理或签名能力变化后不保证保留。
 
 ### 2. 选择运行模式
 


### PR DESCRIPTION
## 改动内容

- 将 App 自签安装说明重写为四个明确步骤
- 补充 iOS 16+ 开启开发者模式的系统路径，并说明 iOS 15 可跳过
- 明确从 Releases 下载未签名 IPA
- 提供 Impact 官方 Release，并允许使用爱思助手等其他自签工具
- 补充 USB 信任、开发者 App 信任、Windows 驱动和第三方工具安全提示
- 同步更新中英文 README

## 原因

原安装说明把下载、签名和设备准备混在段落中，新用户不容易按顺序完成。新的四步流程可直接照着操作。

## 影响

仅更新文档，不改变应用、构建或发布行为。

## 校验

- `git diff --check -- README.md README.en.md`
- 确认两份 README 为 UTF-8
- 确认 Impact 最新 Release 提供 Windows、macOS 和 Linux 构建
- 确认相对上游 `main` 仅修改 `README.md`、`README.en.md`
